### PR TITLE
UserSerciceTest completos + configuntacion

### DIFF
--- a/VivesBankApi/Rest/Users/Controller/UserController.cs
+++ b/VivesBankApi/Rest/Users/Controller/UserController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using VivesBankApi.Rest.Users.Dtos;
 using VivesBankApi.Rest.Users.Mapper;
-using VivesBankApi.Rest.Users.Models;
 using VivesBankApi.Rest.Users.Service;
 
 namespace VivesBankApi.Rest.Users.Controller;

--- a/VivesBankApi/Rest/Users/Mapper/UserMapper.cs
+++ b/VivesBankApi/Rest/Users/Mapper/UserMapper.cs
@@ -4,9 +4,9 @@ using VivesBankApi.Rest.Users.Models;
 
 namespace VivesBankApi.Rest.Users.Mapper;
 
-class UserMapper
+public class UserMapper
 {
-    protected UserMapper(){}
+    protected  UserMapper(){}
     
     public static UserResponse ToUserResponse(User user)
     {


### PR DESCRIPTION
He completado los tests del servicio de usuarios y he modificado el mapper de usuarios para que sea público y pueda ser utilizado desde los tests. También he eliminado un `using` innecesario en el controlador de usuarios.