### PR TITLE
Mejora en el manejo de errores al enviar notificaciones por WebSockets

### DIFF
--- a/VivesBankApi/Utils/ExceptionMiddleware/GlobalExceptionMiddleware.cs
+++ b/VivesBankApi/Utils/ExceptionMiddleware/GlobalExceptionMiddleware.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.WebSockets;
 using System.Text.Json;
 using VivesBankApi.Backup.Exceptions;
 using VivesBankApi.Rest.Clients.Exceptions;
@@ -168,6 +169,13 @@ public class GlobalExceptionMiddleware(RequestDelegate next, ILogger<GlobalExcep
                 
                 case ClientExceptions.ClientNotFoundException:
                     statusCode = HttpStatusCode.NotFound;
+                    errorResponse = new { message = exception.Message };
+                    logger.LogWarning(exception, exception.Message);
+                    break;
+                
+                /************************** WEBSOCKET EXCEPTIONS *****************************************************/
+                case WebSocketException:
+                    statusCode = HttpStatusCode.BadGateway;
                     errorResponse = new { message = exception.Message };
                     logger.LogWarning(exception, exception.Message);
                     break;

--- a/VivesBankApi/WebSocket/Service/WebSocketHandler.cs
+++ b/VivesBankApi/WebSocket/Service/WebSocketHandler.cs
@@ -52,7 +52,6 @@ public class WebSocketHandler : IWebsocketHandler
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async Task NotifyAllAsync<T>(Notification<T> notification)
     {
-        // Serialize notification to JSON while ignoring null values
         var jsonSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
@@ -62,11 +61,21 @@ public class WebSocketHandler : IWebsocketHandler
         _logger.LogInformation($"Notifying all clients: {json}");
 
         var buffer = Encoding.UTF8.GetBytes(json);
+    
+        var tasks = _sockets.Select(async socket =>
+        {
+            try
+            {
+                await socket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
+            }
+            catch (WebSocketException ex)
+            {
+                _logger.LogError($"Error sending WebSocket message: {ex.Message}");
+                throw new WebSocketException($"Failed to send notification: {ex.Message}", ex);
+            }
+        }).ToArray();
 
-        var tasks = _sockets.Select(socket =>
-            socket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None))
-            .ToArray();
-        await Task.WhenAll(tasks); 
+        await Task.WhenAll(tasks);
     }
 
     /// <summary>
@@ -78,22 +87,37 @@ public class WebSocketHandler : IWebsocketHandler
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async Task NotifyUserAsync<T>(string username, Notification<T> notification)
     {
-        if (_userSockets.TryGetValue(username, out var socket))
+        if (!_userSockets.TryGetValue(username, out var socket))
         {
-            var jsonSettings = new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                Formatting = Formatting.Indented
-            };
-            var json = JsonConvert.SerializeObject(notification, jsonSettings);
-            var buffer = Encoding.UTF8.GetBytes(json);
+            _logger.LogWarning($"User '{username}' not found.");
+            throw new InvalidOperationException($"Cannot send notification. User '{username}' is not connected.");
+        }
 
+        if (socket.State != WebSocketState.Open)
+        {
+            _logger.LogError($"WebSocket for user '{username}' is not open. Current state: {socket.State}");
+            throw new WebSocketException($"Cannot send message. WebSocket for user '{username}' is in state: {socket.State}");
+        }
+
+        var jsonSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = Formatting.Indented
+        };
+        var json = JsonConvert.SerializeObject(notification, jsonSettings);
+        var buffer = Encoding.UTF8.GetBytes(json);
+        
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+
+        try
+        {
             await socket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);
             _logger.LogInformation($"Notification sent to {username}: {json}");
         }
-        else
+        catch (WebSocketException ex)
         {
-            _logger.LogWarning($"User '{username}' not found.");
+            _logger.LogError($"Failed to send WebSocket message to {username}: {ex.Message}");
+            throw new WebSocketException($"Error sending WebSocket message to {username}: {ex.Message}", ex);
         }
     }
 

--- a/VivesBankApi/WebSocket/Service/WebSocketHandler.cs
+++ b/VivesBankApi/WebSocket/Service/WebSocketHandler.cs
@@ -107,8 +107,6 @@ public class WebSocketHandler : IWebsocketHandler
         var json = JsonConvert.SerializeObject(notification, jsonSettings);
         var buffer = Encoding.UTF8.GetBytes(json);
         
-        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
-
         try
         {
             await socket.SendAsync(new ArraySegment<byte>(buffer), WebSocketMessageType.Text, true, CancellationToken.None);


### PR DESCRIPTION
Agrega un mejor manejo de errores en el método NotifyAllAsync y NotifyUserAsync para garantizar que si un mensaje no se envía correctamente, se lance una excepción y se registre el error en los logs.

✏️Cambios realizados:
- Se agregó un bloque try-catch dentro del Select para capturar cualquier error al enviar un mensaje por WebSocket.
- Si SendAsync falla en algún socket, se captura la excepción y se lanza una nueva WebSocketException con detalles del error.
- Se agregó un log de error (_logger.LogError) para registrar fallos en el envío de mensajes.
- Se asegura que todas las tareas de envío terminen antes de continuar utilizando await Task.WhenAll(tasks);.

⚠️Se ha intentado comprobar el funcionamiento del cambio, pero debido a errores en otras funciones (movimientos) no se ha podido verificar correctamente